### PR TITLE
Added features for agent_install and additional node_groups

### DIFF
--- a/plans/install.pp
+++ b/plans/install.pp
@@ -13,6 +13,8 @@ plan pe_xl::install (
 
   Optional[String[1]] $load_balancer_host = undef,
 
+  Optional[String[1]] $deploy_environment = 'production',
+
   String[1]           $stagingdir = '/tmp',
 ) {
 
@@ -210,7 +212,17 @@ plan pe_xl::install (
       --allow-dns-alt-names
     | HEREDOC
 
-  run_task('pe_xl::puppet_runonce', $agent_installer_hosts)
+  $merged = $r10k_sources.reduce |$memo, $value| {
+    $string = "${memo[0]}${value[0]}"
+  }
+
+  if $merged {
+    run_task('pe_xl::code_manager', $primary_master_host,
+      action => 'deploy',
+      environment => $deploy_environment,
+    )
+  }
+
   run_task('pe_xl::puppet_runonce', $pe_installer_hosts)
 
   return('Installation succeeded')

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -163,36 +163,30 @@ plan pe_xl::install (
 
   # Deploy the PE agent to all remaining hosts
   run_task('pe_xl::agent_install', $primary_master_replica_host,
-    server        => $primary_master_host,
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::primary_master',
-      'extension_requests:pp_cluster=B',
-    ],
+    master            => $primary_master_host,
+    command_options   => '--puppet-service-ensure stopped',
+    dns_alt_names     => $dns_alt_names_csv,
+    extension_request => 'pp_application=puppet
+      extension_requests:pp_role=pe_xl::primary_master
+      extension_requests:pp_cluster=B',
   )
 
   # TODO: Split the compile masters into two pools, A and B.
   run_task('pe_xl::agent_install', $compile_master_hosts,
-    server        => $primary_master_host,
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::compile_master',
-      'extension_requests:pp_cluster=A',
-    ],
+    master            => $primary_master_host,
+    command_options   =>  '--puppet-service-ensure stopped',
+    dns_alt_names     => $dns_alt_names_csv,
+    extension_request => 'pp_application=puppet
+      extension_requests:pp_role=pe_xl::compile_master
+      extension_requests:pp_cluster=A',
   )
 
   if $load_balancer_host {
     run_task('pe_xl::agent_install', $load_balancer_host,
-      server        => $primary_master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::load_balancer',
-      ],
+      master          => $primary_master_host,
+      command_options => '--puppet-service-ensure stopped',
+      extension_request => 'pp_application=puppet
+        extension_requests:pp_role=pe_xl::load_balancer',
     )
   }
 

--- a/tasks/agent_install.json
+++ b/tasks/agent_install.json
@@ -1,17 +1,38 @@
 {
-  "description": "Install the Puppet agent from a master",
-  "parameters": {
-    "server": {
-      "type": "String",
-      "description": "The resolvable name of the Puppet server to install from"
-    },
-    "install_flags": {
-      "type": "Array[String]",
-      "description": "Positional arguments to pass to the shell installer"
-    }
-  },
+  "description": "Bootstrap a node with puppet-agent for Linux",
   "input_method": "environment",
-  "implementations": [
-    {"name": "agent_install.sh"}
-  ]
+  "parameters": {
+    "master": {
+      "description": "The master from which the puppet-agent should be bootstrapped",
+      "type": "String"
+    },
+    "cacert_content": {
+      "description": "The expected CA certificate content for the master",
+      "type": "Optional[String]"
+    },
+    "certname": {
+      "description": "The certname with which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "environment": {
+      "description": "The environment in which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "command_options": {
+      "description": "The additional options to be passed to the install.bash installer",
+      "type": "Optional[String]"
+    },
+    "dns_alt_names": {
+      "description": "The DNS alt names with which the agent certificate should be generated",
+      "type": "Optional[String]"
+    },
+    "custom_attribute": {
+      "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
+      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+    },
+    "extension_request": {
+      "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
+      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+    }
+  }
 }

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,6 +1,67 @@
 #!/bin/bash
+#
+#set -e
+#
+#flags=$(echo "$PT_install_flags" | tr '[],"' ' ')
+#
+#curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
+#!/bin/sh
+
+validate() {
+  if $(echo $1 | grep \' > /dev/null) ; then
+    echo "Single-quote is not allowed in arguments" > /dev/stderr
+    exit 1
+  fi
+}
+
+master="$PT_master"
+cacert_content="$PT_cacert_content"
+certname="$PT_certname"
+environment="$PT_environment"
+command_options="$PT_command_options"
+alt_names="$PT_dns_alt_names"
+custom_attribute="$PT_custom_attribute"
+extension_request="$PT_extension_request"
+
+validate $certname
+validate $environment
+validate $alt_names
+
+if [ -n "${certname?}" ] ; then
+  certname_arg="agent:certname='${certname}' "
+fi
+if [ -n "${environment?}" ] ; then
+  alt_names_arg="agent:environment='${environment}' "
+fi
+if [ -n "${alt_names?}" ] ; then
+  alt_names_arg="agent:dns_alt_names='${alt_names}' "
+fi
+if [ -n "${custom_attribute?}" ] ; then
+  custom_attributes_arg="custom_attributes:$custom_attribute "
+fi
+if [ -n "${extension_request?}" ] ; then
+  extension_requests_arg="extension_requests:$extension_request "
+fi
 
 set -e
 
-flags=$(echo $PT_install_flags | tr -d '[],\ "\ ')
-curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
+[ -d /etc/puppetlabs/puppet/ssl/certs ] || mkdir -p /etc/puppetlabs/puppet/ssl/certs
+if [ -n "${cacert_content?}" ]; then
+  echo "${cacert_content}" > /etc/puppetlabs/puppet/ssl/certs/ca.pem
+  curl_arg="--cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem"
+else
+  curl_arg="-k"
+fi
+
+if curl ${curl_arg?} https://${master}:8140/packages/current/install.bash -o /tmp/install.bash; then
+  if bash /tmp/install.bash ${command_options} ${certname_arg}${alt_names_arg}${custom_attributes_arg}${extension_requests_arg}; then
+    echo "Installed"
+    exit 0
+  else
+    echo "Failed to run install.bash"
+    exit 1
+  fi
+else
+  echo "Failed to download install.bash"
+  exit 1
+fi

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-flags=$(echo $PT_install_flags | tr -d '[],"')
+flags=$(echo $PT_install_flags | tr -d '[],\ "\ ')
 curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 #
-#set -e
-#
-#flags=$(echo "$PT_install_flags" | tr '[],"' ' ')
-#
-#curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
-#!/bin/sh
+# Modified orig source was 'https://github.com/puppetlabs/puppetlabs-bootstrap/blob/master/tasks/linux.sh'
+#  Added additional option to manage command_options
 
 validate() {
   if $(echo $1 | grep \' > /dev/null) ; then

--- a/tasks/code_manager.json
+++ b/tasks/code_manager.json
@@ -1,6 +1,10 @@
 {
   "description": "Perform various code manager actions",
   "parameters": {
+    "environment": {
+      "type": "Optional[String]",
+      "description": "Which environment should be deployed"
+    },
     "action": {
       "type": "Enum['deploy','commit','flush-environment-cache','file-sync commit']",
       "description": "Which code manager action to perform"

--- a/tasks/code_manager.sh
+++ b/tasks/code_manager.sh
@@ -70,7 +70,7 @@ function main()
 function deploy()
 {
   [ "$#" = 1 ] || { echo "specify an environment to deploy"; exit 1; }
-  cm_r10k deploy environment "$1" && commit
+  cm_r10k deploy environment "$PT_environment" && commit
 }
 
 function commit()
@@ -164,4 +164,4 @@ function curl_wrapper()
   fi
 }
 
-main $PT_action
+main $PT_action $PT_environment

--- a/tasks/configure_node_groups.pp
+++ b/tasks/configure_node_groups.pp
@@ -26,6 +26,36 @@ node_group { 'PE PuppetDB':
   ],
 }
 
+if param('load_balancer_host') {
+  node_group { 'PE Load Balancer':
+    ensure               => 'present',
+    classes              => {
+      'profile::haproxy' => {
+      }
+    },
+    parent               => 'PE Infrastructure',
+    rule                 => ['and',
+    ['~',
+      ['trusted', 'extensions', 'pp_role'],
+      'pe_xl::load_balancer']],
+  }
+}
+
+if param('compile_master_hosts') {
+  node_group { 'PE Compile Masters':
+    ensure               => 'present',
+    classes              => {
+      'profile::compile_master' => {
+      }
+    },
+    parent               => 'PE Master',
+    rule                 => ['and',
+    ['=',
+      ['trusted', 'extensions', 'pp_role'],
+      'pe_xl::compile_master']],
+  }
+}
+
 # This class has to be included here because puppet_enterprise is declared
 # in the console with parameters. It is therefore not possible to include
 # puppet_enterprise::profile::database in code without causing a conflict.
@@ -82,3 +112,4 @@ $environments.each |$env| {
     rule                 => ['and', ['~', ['fact', 'agent_specified_environment'], '.+']],
   }
 }
+


### PR DESCRIPTION
This code was to make the install process more stable and add some additional options for the agent_install.sh.  

The additional node groups are conditional on if a cluster has compilemasters and/or loadbalancer configured.

