### PR TITLE
Install and Configure changes

### DIFF
--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -1,12 +1,25 @@
 plan pe_xl::configure (
+
+  String[1]           $version = '2018.1.2',
+  String[1]           $console_password,
+  Hash                $r10k_sources = { },
+
   String[1]           $primary_master_host,
   String[1]           $puppetdb_database_host,
   Array[String[1]]    $compile_master_hosts = [ ],
+  Array[String[1]]    $dns_alt_names = [ ],
+
   Optional[String[1]] $primary_master_replica_host = undef,
   Optional[String[1]] $puppetdb_database_replica_host = undef,
 
+  Optional[String[1]] $load_balancer_host = undef,
+
   String[1]           $stagingdir = '/tmp',
 ) {
+
+  run_task('pe_xl::configure_node_groups', $primary_master_host,
+    primary_master_host => $primary_master_host
+  )
 
   $nm_module_tarball = 'WhatsARanjit-node_manager-0.7.1.tar.gz'
   pe_xl::retrieve_and_upload(
@@ -38,4 +51,31 @@ plan pe_xl::configure (
     $primary_master_replica_host,
     $puppetdb_database_replica_host,
   ])
+
+  # Run the PE Replica Provision
+  run_task('pe_xl::provision_replica', $primary_master_host,
+    primary_master_replica => $primary_master_replica_host,
+  )
+
+  run_task('pe_xl::puppet_runonce', [
+    $primary_master_host,
+    $primary_master_replica_host,
+  ])
+
+  run_task(pe_xl::configure_replica_db_node_group, $primary_master_host,
+    puppetdb_database_replica_host => $puppetdb_database_replica_host,
+  )
+  if $compile_master_hosts {
+    run_task('pe_xl::puppet_runonce', $compile_master_hosts)
+  }
+
+  if $load_balancer_host {
+    run_task('pe_xl::puppet_runonce', $load_balancer_host)
+  }
+
+  if $compile_master_hosts {
+    run_task('pe_xl::puppet_runonce', $compile_master_hosts)
+  }
+
+  return('Configuration of Puppet Enterprise with replica succeeded.')
 }

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -13,6 +13,8 @@ plan pe_xl::install (
 
   Optional[String[1]] $load_balancer_host = undef,
 
+  Optional[String[1]] $deploy_environment = 'production',
+
   String[1]           $stagingdir = '/tmp',
 ) {
 
@@ -210,7 +212,17 @@ plan pe_xl::install (
       --allow-dns-alt-names
     | HEREDOC
 
-  run_task('pe_xl::puppet_runonce', $agent_installer_hosts)
+  $merged = $r10k_sources.reduce |$memo, $value| {
+    $string = "${memo[0]}${value[0]}"
+  }
+
+  if $merged {
+    run_task('pe_xl::code_manager', $primary_master_host,
+      action => 'deploy',
+      environment => $deploy_environment,
+    )
+  }
+
   run_task('pe_xl::puppet_runonce', $pe_installer_hosts)
 
   return('Installation succeeded')

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -163,36 +163,30 @@ plan pe_xl::install (
 
   # Deploy the PE agent to all remaining hosts
   run_task('pe_xl::agent_install', $primary_master_replica_host,
-    server        => $primary_master_host,
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::primary_master',
-      'extension_requests:pp_cluster=B',
-    ],
+    master            => $primary_master_host,
+    command_options   => '--puppet-service-ensure stopped',
+    dns_alt_names     => $dns_alt_names_csv,
+    extension_request => 'pp_application=puppet
+      extension_requests:pp_role=pe_xl::primary_master
+      extension_requests:pp_cluster=B',
   )
 
   # TODO: Split the compile masters into two pools, A and B.
   run_task('pe_xl::agent_install', $compile_master_hosts,
-    server        => $primary_master_host,
-    install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::compile_master',
-      'extension_requests:pp_cluster=A',
-    ],
+    master            => $primary_master_host,
+    command_options   =>  '--puppet-service-ensure stopped',
+    dns_alt_names     => $dns_alt_names_csv,
+    extension_request => 'pp_application=puppet
+      extension_requests:pp_role=pe_xl::compile_master
+      extension_requests:pp_cluster=A',
   )
 
   if $load_balancer_host {
     run_task('pe_xl::agent_install', $load_balancer_host,
-      server        => $primary_master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::load_balancer',
-      ],
+      master          => $primary_master_host,
+      command_options => '--puppet-service-ensure stopped',
+      extension_request => 'pp_application=puppet
+        extension_requests:pp_role=pe_xl::load_balancer',
     )
   }
 

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -18,6 +18,33 @@ plan pe_xl::install (
   String[1]           $stagingdir = '/tmp',
 ) {
 
+  # split hosts compilemasters to even then odd group a, b
+  if ! $compile_master_hosts.empty{
+    $cmaster_group_a = $compile_master_hosts.filter | $name | { $name =~ /^[a-z]+.*([0,2,4,6,8])\./ }
+    $cmaster_group_b = $compile_master_hosts.filter | $name | { $name =~ /^[a-z]+.*([1,3,5,7,9])\./ }
+    $group_a = [
+      $primary_master_host, 
+      $puppetdb_database_host,
+      $cmaster_group_a,
+    ].pe_xl::flatten_compact()
+  
+    $group_b = [
+      $primary_master_replica_host,
+      $puppetdb_database_replica_host,
+      $cmaster_group_b,
+    ].pe_xl::flatten_compact()
+  } else {
+    $group_a = [
+      $primary_master_host, 
+      $puppetdb_database_host,
+    ].pe_xl::flatten_compact()
+  
+    $group_b = [
+      $primary_master_replica_host,
+      $puppetdb_database_replica_host,
+    ].pe_xl::flatten_compact()
+  }
+
   $all_hosts = [
     $primary_master_host, 
     $puppetdb_database_host,
@@ -38,7 +65,6 @@ plan pe_xl::install (
     $load_balancer_host,
     $primary_master_replica_host,
   ].pe_xl::flatten_compact()
-
 
   $dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
 
@@ -163,30 +189,48 @@ plan pe_xl::install (
 
   # Deploy the PE agent to all remaining hosts
   run_task('pe_xl::agent_install', $primary_master_replica_host,
-    master            => $primary_master_host,
-    command_options   => '--puppet-service-ensure stopped',
-    dns_alt_names     => $dns_alt_names_csv,
-    extension_request => 'pp_application=puppet
-      extension_requests:pp_role=pe_xl::primary_master
-      extension_requests:pp_cluster=B',
+    server        => $primary_master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::primary_master',
+      'extension_requests:pp_cluster=B',
+    ],
   )
 
   # TODO: Split the compile masters into two pools, A and B.
-  run_task('pe_xl::agent_install', $compile_master_hosts,
-    master            => $primary_master_host,
-    command_options   =>  '--puppet-service-ensure stopped',
-    dns_alt_names     => $dns_alt_names_csv,
-    extension_request => 'pp_application=puppet
-      extension_requests:pp_role=pe_xl::compile_master
-      extension_requests:pp_cluster=A',
+  run_task('pe_xl::agent_install', $cmaster_group_a,
+    server        => $primary_master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::compile_master',
+      'extension_requests:pp_cluster=A',
+    ],
+  )
+
+  # TODO: Split the compile masters into two pools, A and B.
+  run_task('pe_xl::agent_install', $cmaster_group_b,
+    server        => $primary_master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::compile_master',
+      'extension_requests:pp_cluster=B',
+    ],
   )
 
   if $load_balancer_host {
     run_task('pe_xl::agent_install', $load_balancer_host,
-      master          => $primary_master_host,
-      command_options => '--puppet-service-ensure stopped',
-      extension_request => 'pp_application=puppet
-        extension_requests:pp_role=pe_xl::load_balancer',
+      server        => $primary_master_host,
+      install_flags => [
+        '--puppet-service-ensure', 'stopped',
+        'extension_requests:pp_application=puppet',
+        'extension_requests:pp_role=pe_xl::load_balancer',
+      ],
     )
   }
 
@@ -206,18 +250,29 @@ plan pe_xl::install (
       --allow-dns-alt-names
     | HEREDOC
 
-  $merged = $r10k_sources.reduce |$memo, $value| {
+  $control_repo = $r10k_sources.reduce |$memo, $value| {
     $string = "${memo[0]}${value[0]}"
   }
 
-  if $merged {
+  if $control_repo {
     run_task('pe_xl::code_manager', $primary_master_host,
       action => 'deploy',
       environment => $deploy_environment,
     )
   }
 
-  run_task('pe_xl::puppet_runonce', $pe_installer_hosts)
+  run_task('pe_xl::puppet_runonce', $primary_master_host)
+  run_task('pe_xl::puppet_runonce', $puppetdb_database_host)
+  run_task('pe_xl::puppet_runonce', $primary_master_replica_host)
+  run_task('pe_xl::puppet_runonce', $puppetdb_database_replica_host)
+  if ! $compile_master_hosts.empty {
+    $compile_master_hosts.each |$host| {
+      run_task('pe_xl::puppet_runonce', $host)
+    }
+  }
+  if $load_balancer_host {
+    run_task('pe_xl::puppet_runonce', $load_balancer_host)
+  }
 
   return('Installation succeeded')
 }

--- a/tasks/agent_install.json
+++ b/tasks/agent_install.json
@@ -1,38 +1,17 @@
 {
-  "description": "Bootstrap a node with puppet-agent for Linux",
-  "input_method": "environment",
+  "description": "Install the Puppet agent from a master",
   "parameters": {
-    "master": {
-      "description": "The master from which the puppet-agent should be bootstrapped",
-      "type": "String"
+    "server": {
+      "type": "String",
+      "description": "The resolvable name of the Puppet server to install from"
     },
-    "cacert_content": {
-      "description": "The expected CA certificate content for the master",
-      "type": "Optional[String]"
-    },
-    "certname": {
-      "description": "The certname with which the node should be bootstrapped",
-      "type": "Optional[String]"
-    },
-    "environment": {
-      "description": "The environment in which the node should be bootstrapped",
-      "type": "Optional[String]"
-    },
-    "command_options": {
-      "description": "The additional options to be passed to the install.bash installer",
-      "type": "Optional[String]"
-    },
-    "dns_alt_names": {
-      "description": "The DNS alt names with which the agent certificate should be generated",
-      "type": "Optional[String]"
-    },
-    "custom_attribute": {
-      "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
-      "type": "Optional[Pattern[/\\w+=\\w+/]]"
-    },
-    "extension_request": {
-      "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
-      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+    "install_flags": {
+      "type": "Array[String]",
+      "description": "Positional arguments to pass to the shell installer"
     }
-  }
+  },
+  "input_method": "environment",
+  "implementations": [
+    {"name": "agent_install.sh"}
+  ]
 }

--- a/tasks/agent_install.json
+++ b/tasks/agent_install.json
@@ -1,17 +1,38 @@
 {
-  "description": "Install the Puppet agent from a master",
-  "parameters": {
-    "server": {
-      "type": "String",
-      "description": "The resolvable name of the Puppet server to install from"
-    },
-    "install_flags": {
-      "type": "Array[String]",
-      "description": "Positional arguments to pass to the shell installer"
-    }
-  },
+  "description": "Bootstrap a node with puppet-agent for Linux",
   "input_method": "environment",
-  "implementations": [
-    {"name": "agent_install.sh"}
-  ]
+  "parameters": {
+    "master": {
+      "description": "The master from which the puppet-agent should be bootstrapped",
+      "type": "String"
+    },
+    "cacert_content": {
+      "description": "The expected CA certificate content for the master",
+      "type": "Optional[String]"
+    },
+    "certname": {
+      "description": "The certname with which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "environment": {
+      "description": "The environment in which the node should be bootstrapped",
+      "type": "Optional[String]"
+    },
+    "command_options": {
+      "description": "The additional options to be passed to the install.bash installer",
+      "type": "Optional[String]"
+    },
+    "dns_alt_names": {
+      "description": "The DNS alt names with which the agent certificate should be generated",
+      "type": "Optional[String]"
+    },
+    "custom_attribute": {
+      "description": "This setting is added to puppet.conf and included in the custom_attributes section of csr_attributes.yaml",
+      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+    },
+    "extension_request": {
+      "description": "This setting is added to puppet.conf and included in the extension_requests section of csr_attributes.yaml",
+      "type": "Optional[Pattern[/\\w+=\\w+/]]"
+    }
+  }
 }

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,6 +1,67 @@
 #!/bin/bash
+#
+#set -e
+#
+#flags=$(echo "$PT_install_flags" | tr '[],"' ' ')
+#
+#curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
+#!/bin/sh
+
+validate() {
+  if $(echo $1 | grep \' > /dev/null) ; then
+    echo "Single-quote is not allowed in arguments" > /dev/stderr
+    exit 1
+  fi
+}
+
+master="$PT_master"
+cacert_content="$PT_cacert_content"
+certname="$PT_certname"
+environment="$PT_environment"
+command_options="$PT_command_options"
+alt_names="$PT_dns_alt_names"
+custom_attribute="$PT_custom_attribute"
+extension_request="$PT_extension_request"
+
+validate $certname
+validate $environment
+validate $alt_names
+
+if [ -n "${certname?}" ] ; then
+  certname_arg="agent:certname='${certname}' "
+fi
+if [ -n "${environment?}" ] ; then
+  alt_names_arg="agent:environment='${environment}' "
+fi
+if [ -n "${alt_names?}" ] ; then
+  alt_names_arg="agent:dns_alt_names='${alt_names}' "
+fi
+if [ -n "${custom_attribute?}" ] ; then
+  custom_attributes_arg="custom_attributes:$custom_attribute "
+fi
+if [ -n "${extension_request?}" ] ; then
+  extension_requests_arg="extension_requests:$extension_request "
+fi
 
 set -e
 
-flags=$(echo $PT_install_flags | tr -d '[],\ "\ ')
-curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
+[ -d /etc/puppetlabs/puppet/ssl/certs ] || mkdir -p /etc/puppetlabs/puppet/ssl/certs
+if [ -n "${cacert_content?}" ]; then
+  echo "${cacert_content}" > /etc/puppetlabs/puppet/ssl/certs/ca.pem
+  curl_arg="--cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem"
+else
+  curl_arg="-k"
+fi
+
+if curl ${curl_arg?} https://${master}:8140/packages/current/install.bash -o /tmp/install.bash; then
+  if bash /tmp/install.bash ${command_options} ${certname_arg}${alt_names_arg}${custom_attributes_arg}${extension_requests_arg}; then
+    echo "Installed"
+    exit 0
+  else
+    echo "Failed to run install.bash"
+    exit 1
+  fi
+else
+  echo "Failed to download install.bash"
+  exit 1
+fi

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,43 +1,4 @@
 #!/bin/bash
-#
-# Modified orig source was 'https://github.com/puppetlabs/puppetlabs-bootstrap/blob/master/tasks/linux.sh'
-#  Added additional option to manage command_options
-
-validate() {
-  if $(echo $1 | grep \' > /dev/null) ; then
-    echo "Single-quote is not allowed in arguments" > /dev/stderr
-    exit 1
-  fi
-}
-
-master="$PT_master"
-cacert_content="$PT_cacert_content"
-certname="$PT_certname"
-environment="$PT_environment"
-command_options="$PT_command_options"
-alt_names="$PT_dns_alt_names"
-custom_attribute="$PT_custom_attribute"
-extension_request="$PT_extension_request"
-
-validate $certname
-validate $environment
-validate $alt_names
-
-if [ -n "${certname?}" ] ; then
-  certname_arg="agent:certname='${certname}' "
-fi
-if [ -n "${environment?}" ] ; then
-  alt_names_arg="agent:environment='${environment}' "
-fi
-if [ -n "${alt_names?}" ] ; then
-  alt_names_arg="agent:dns_alt_names='${alt_names}' "
-fi
-if [ -n "${custom_attribute?}" ] ; then
-  custom_attributes_arg="custom_attributes:$custom_attribute "
-fi
-if [ -n "${extension_request?}" ] ; then
-  extension_requests_arg="extension_requests:$extension_request "
-fi
 
 set -e
 

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-flags=$(echo $PT_install_flags | tr -d '[],"')
+flags=$(echo $PT_install_flags | tr -d '[],\ "\ ')
 curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -41,23 +41,6 @@ fi
 
 set -e
 
-[ -d /etc/puppetlabs/puppet/ssl/certs ] || mkdir -p /etc/puppetlabs/puppet/ssl/certs
-if [ -n "${cacert_content?}" ]; then
-  echo "${cacert_content}" > /etc/puppetlabs/puppet/ssl/certs/ca.pem
-  curl_arg="--cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem"
-else
-  curl_arg="-k"
-fi
+flags=$(echo $PT_install_flags | sed -e 's/^\["//' -e 's/\"]$//' -e 's/", *"/ /g')
 
-if curl ${curl_arg?} https://${master}:8140/packages/current/install.bash -o /tmp/install.bash; then
-  if bash /tmp/install.bash ${command_options} ${certname_arg}${alt_names_arg}${custom_attributes_arg}${extension_requests_arg}; then
-    echo "Installed"
-    exit 0
-  else
-    echo "Failed to run install.bash"
-    exit 1
-  fi
-else
-  echo "Failed to download install.bash"
-  exit 1
-fi
+curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags

--- a/tasks/agent_install.sh
+++ b/tasks/agent_install.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 #
-#set -e
-#
-#flags=$(echo "$PT_install_flags" | tr '[],"' ' ')
-#
-#curl -k "https://${PT_server}:8140/packages/current/install.bash" | bash -s -- $flags
-#!/bin/sh
+# Modified orig source was 'https://github.com/puppetlabs/puppetlabs-bootstrap/blob/master/tasks/linux.sh'
+#  Added additional option to manage command_options
 
 validate() {
   if $(echo $1 | grep \' > /dev/null) ; then

--- a/tasks/code_manager.json
+++ b/tasks/code_manager.json
@@ -1,6 +1,10 @@
 {
   "description": "Perform various code manager actions",
   "parameters": {
+    "environment": {
+      "type": "Optional[String]",
+      "description": "Which environment should be deployed"
+    },
     "action": {
       "type": "Enum['deploy','commit','flush-environment-cache','file-sync commit']",
       "description": "Which code manager action to perform"

--- a/tasks/code_manager.sh
+++ b/tasks/code_manager.sh
@@ -70,7 +70,7 @@ function main()
 function deploy()
 {
   [ "$#" = 1 ] || { echo "specify an environment to deploy"; exit 1; }
-  cm_r10k deploy environment "$1" && commit
+  cm_r10k deploy environment "$PT_environment" && commit
 }
 
 function commit()
@@ -164,4 +164,4 @@ function curl_wrapper()
   fi
 }
 
-main $PT_action
+main $PT_action $PT_environment

--- a/tasks/configure_node_groups.json
+++ b/tasks/configure_node_groups.json
@@ -4,6 +4,18 @@
     "primary_master_host": {
       "type": "String",
       "description": "The certname of the primary master"
+    },
+    "r10k_sources": {
+      "type": "Optional['Hash']",
+      "description": "The r10k control repos"
+    },
+    "compile_master_hosts": {
+      "type": "Optional['Array']",
+      "description": "The certname of all the compile masters"
+    },
+    "load_balancer_host": {
+      "type": "Optional['String']",
+      "description": "The certname of the load balancer"
     }
   },
   "input_method": "environment",

--- a/tasks/configure_node_groups.pp
+++ b/tasks/configure_node_groups.pp
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/bin/puppet apply
+#!/opt/puppetlabs/bin/puppet apply 
 function param($name) { inline_template("<%= ENV['PT_${name}'] %>") }
 
 $default_environment = 'production'

--- a/tasks/configure_node_groups.pp
+++ b/tasks/configure_node_groups.pp
@@ -26,6 +26,36 @@ node_group { 'PE PuppetDB':
   ],
 }
 
+if param('load_balancer_host') {
+  node_group { 'PE Load Balancer':
+    ensure               => 'present',
+    classes              => {
+      'profile::haproxy' => {
+      }
+    },
+    parent               => 'PE Infrastructure',
+    rule                 => ['and',
+    ['~',
+      ['trusted', 'extensions', 'pp_role'],
+      'pe_xl::load_balancer']],
+  }
+}
+
+if param('compile_master_hosts') {
+  node_group { 'PE Compile Masters':
+    ensure               => 'present',
+    classes              => {
+      'profile::compile_master' => {
+      }
+    },
+    parent               => 'PE Master',
+    rule                 => ['and',
+    ['=',
+      ['trusted', 'extensions', 'pp_role'],
+      'pe_xl::compile_master']],
+  }
+}
+
 # This class has to be included here because puppet_enterprise is declared
 # in the console with parameters. It is therefore not possible to include
 # puppet_enterprise::profile::database in code without causing a conflict.
@@ -82,3 +112,4 @@ $environments.each |$env| {
     rule                 => ['and', ['~', ['fact', 'agent_specified_environment'], '.+']],
   }
 }
+

--- a/tasks/configure_replica_db_node_group.json
+++ b/tasks/configure_replica_db_node_group.json
@@ -1,0 +1,13 @@
+{
+  "description": "Add replica DB to the node_group",
+  "parameters": {
+    "puppetdb_database_replica_host": {
+      "type": "String",
+      "description": "The certname of the replica database node"
+    }
+  },
+  "input_method": "environment",
+  "implementations": [
+    {"name": "configure_replica_db_node_group.pp"}
+  ]
+}

--- a/tasks/configure_replica_db_node_group.pp
+++ b/tasks/configure_replica_db_node_group.pp
@@ -1,0 +1,13 @@
+#!/opt/puppetlabs/bin/puppet apply
+function param($name) { inline_template("<%= ENV['PT_${name}'] %>") }
+
+$puppetdb_database_replica_host=param('puppetdb_database_replica_host')
+
+node_group { 'PE HA Replica':
+  ensure   => 'present',
+  classes  => {
+    'puppet_enterprise::profile::primary_master_replica' => {
+      'database_host_puppetdb' => $puppetdb_database_replica_host
+    }
+  },
+}

--- a/tasks/provision_replica.json
+++ b/tasks/provision_replica.json
@@ -1,0 +1,13 @@
+{
+  "description": "Execute the replica provision puppet command ",
+  "parameters": {
+    "primary_master_replica": {
+      "type": "String",
+      "description": "The path to the Puppet Enterprise tarball"
+    }
+  },
+  "input_method": "environment",
+  "implementations": [
+    {"name": "provision_replica.sh"}
+  ]
+}

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+env PATH=/opt/puppetlabs/bin:$PATH puppet infrastructure provision replica $PT_primary_master_replica
+


### PR DESCRIPTION
This pull request has several changes.

The install is all still to be done with ssh:// transport.  

I made several changes to the configure plan to reflect the ability to use the orchestrator.  This is not fully working yet.

When using an install-params.json:

```
{
  "version": "2018.1.3",
  "console_password": "puppetlabs",
  "primary_master_host": "pe-xl-core-0.cfr.puppet.vm",
  "puppetdb_database_host": "pe-xl-core-1.cfr.puppet.vm",
  "primary_master_replica_host": "pe-xl-core-2.cfr.puppet.vm",
  "puppetdb_database_replica_host": "pe-xl-core-3.cfr.puppet.vm",
  "load_balancer_host": "pe-xl-loadbalancer.cfr.puppet.vm",
  "dns_alt_names": [
    "puppet",
    "puppet.cfr.puppet.vm"
  ],
  "r10k_sources": {
    "main": {
      "remote": "/opt/code/control_repo",
      "prefix": false
    }
  },
  "compile_master_hosts": [
"pe-xl-compilemaster-0.cfr.puppet.vm","pe-xl-compilemaster-1.cfr.puppet.vm"

  ]
}
```
With this json running:
```
bolt plan run pe_xl::install --no-host-key-check -u centos --run-as root --params @/home/centos/install-params.json --modulepath /home/centos/modules
``` 
will install the primary master and primary db host.  This will aslo install the agent on all additional hosts.

Running: 
```
bolt plan run misc::configure --no-host-key-check -u centos --run-as root --params @/home/centos/install-params.json --modulepath /home/centos/modules
```
will configure the replica, replica DB, compile masters, and loadbalancer.

