### PR TITLE
Bugfix for configure_node_groups in the configure plan

### DIFF
--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -13,7 +13,7 @@ plan pe_xl::configure (
   Boolean             $executing_on_primary_master = false,
 
   String[1]           $compile_master_pool_address = $primary_master_host,
-  Boolean             $manage_environment_groups = true,
+  String[1]           $manage_environment_groups = 'true',
   Optional[String[1]] $deploy_environment = undef,
 
   String[1]           $stagingdir = '/tmp',


### PR DESCRIPTION
In the plan the param is listed as a Boolean rather than what we used in the task (String)