### PR TITLE
Adding tokenfile option 

### DIFF
--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -14,6 +14,7 @@ plan pe_xl::configure (
 
   String[1]           $compile_master_pool_address = $primary_master_host,
   Boolean             $manage_environment_groups = true,
+  Optional[String[1]] $token_file = '${HOME}/.puppetlabs/token',
   Optional[String[1]] $deploy_environment = undef,
 
   String[1]           $stagingdir = '/tmp',
@@ -64,11 +65,13 @@ plan pe_xl::configure (
   # Run the PE Replica Provision
   run_task('pe_xl::provision_replica', $primary_master_target,
     primary_master_replica => $primary_master_replica_host,
+    token_file => $token_file,
   )
 
   # Run the PE Replica Enable
   run_task('pe_xl::enable_replica', $primary_master_target,
     primary_master_replica => $primary_master_replica_host,
+    token_file => $token_file,
   )
 
   # Run Puppet everywhere to pick up last remaining config tweaks

--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -14,7 +14,7 @@ plan pe_xl::configure (
 
   String[1]           $compile_master_pool_address = $primary_master_host,
   Boolean             $manage_environment_groups = true,
-  Optional[String[1]] $token_file = '${HOME}/.puppetlabs/token',
+  String[1]           $token_file = '${HOME}/.puppetlabs/token',
   Optional[String[1]] $deploy_environment = undef,
 
   String[1]           $stagingdir = '/tmp',

--- a/tasks/enable_replica.json
+++ b/tasks/enable_replica.json
@@ -4,6 +4,10 @@
     "primary_master_replica": {
       "type": "String",
       "description": "The name of the replica to enable"
+    },
+    "token_file": {
+      "type": "Optional['String']",
+      "description": "The name of the token file to use for auth"
     }
   },
   "input_method": "environment",

--- a/tasks/enable_replica.sh
+++ b/tasks/enable_replica.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
+USER="${USER:=$(id -un)}"
+HOME="${HOME:=$(getent passwd "$USER" | cut -d : -f 6)}"
+
+if [[ "${PT_token_file}x" != 'x' ]] ; then
+  TOKEN_FILE="${PT_token_file}"
+else
+  TOKEN_FILE="${HOME}/.puppetlabs/token"
+fi
+
 set -e
 
 env PATH="/opt/puppetlabs/bin:${PATH}" \
-    USER="${USER:=$(id -un)}" \
-    HOME="${HOME:=$(getent passwd "$USER" | cut -d : -f 6)}" \
+    USER="${USER}" \
+    HOME="${HOME}" \
     puppet infrastructure enable replica "$PT_primary_master_replica" \
       --skip-agent-config \
       --topology mono-with-compile \
-      --yes
+      --yes --token-file "${TOKEN_FILE}"

--- a/tasks/enable_replica.sh
+++ b/tasks/enable_replica.sh
@@ -4,7 +4,7 @@ USER="${USER:=$(id -un)}"
 HOME="${HOME:=$(getent passwd "$USER" | cut -d : -f 6)}"
 
 if [[ "${PT_token_file}x" != 'x' ]] ; then
-  TOKEN_FILE="${PT_token_file}"
+  TOKEN_FILE="$PT_token_file"
 else
   TOKEN_FILE="${HOME}/.puppetlabs/token"
 fi
@@ -12,9 +12,9 @@ fi
 set -e
 
 env PATH="/opt/puppetlabs/bin:${PATH}" \
-    USER="${USER}" \
-    HOME="${HOME}" \
+    USER="$USER" \
+    HOME="$HOME" \
     puppet infrastructure enable replica "$PT_primary_master_replica" \
       --skip-agent-config \
       --topology mono-with-compile \
-      --yes --token-file "${TOKEN_FILE}"
+      --yes --token-file "$TOKEN_FILE"

--- a/tasks/provision_replica.json
+++ b/tasks/provision_replica.json
@@ -4,6 +4,10 @@
     "primary_master_replica": {
       "type": "String",
       "description": "The name of the replica to provision"
+    },
+    "token_file": {
+      "type": "Optional['String']",
+      "description": "The name of the token-file for auth"
     }
   },
   "input_method": "environment",

--- a/tasks/provision_replica.sh
+++ b/tasks/provision_replica.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+USER="${USER:=$(id -un)}"
+HOME="${HOME:=$(getent passwd "$USER" | cut -d : -f 6)}"
+
+if [[ "${PT_token_file}x" != 'x' ]] ; then
+  TOKEN_FILE="$PT_token_file"
+else
+  TOKEN_FILE="${HOME}/.puppetlabs/token"
+fi
+
 set -e
 
 env PATH="/opt/puppetlabs/bin:${PATH}" \
-    USER="${USER:=$(id -un)}" \
-    HOME="${HOME:=$(getent passwd "$USER" | cut -d : -f 6)}" \
-    puppet infrastructure provision replica "$PT_primary_master_replica"
+    USER="$USER" \
+    HOME="$HOME" \
+    puppet infrastructure provision replica --token-file "$TOKEN_FILE" \
+    "$PT_primary_master_replica"


### PR DESCRIPTION
This will allow you to pass a token_file to provision_replica and enable_replica.

This will also expose the param through the configure plan.

