### PR TITLE
(SLV-365) Update the install, configure, and upgrade plans in the pe_xl module to make ha optional

### DIFF
--- a/documentation/install_and_configure_without_ha.md
+++ b/documentation/install_and_configure_without_ha.md
@@ -1,0 +1,67 @@
+# Install and configure Extra Large without HA
+
+* TODO: add this doc as a section to basic_usage.md instead?
+
+Please see the [basic_usage.md](basic_usage.md) document for reference; this document will avoid repeating the information covered there.
+The plans covered in this document can also set up the Extra Large environment without HA by setting the optional `ha` parameter to `false` in the params.json file.
+
+## Basic usage instructions
+
+1. Ensure the hostname of each system is set correctly, to the same value that will be used to connect to the system, and refer to the system as. If the hostname is not set as expected the installation plan will refuse to continue.
+2. Install Bolt on a jumphost. This can be the master, or any other system.
+3. Download or git clone the pe\_xl module and put it somewhere on the jumphost, e.g. ~/modules/pe\_xl.
+4. Create an inventory file with connection information. An example is included below.
+5. Create a parameters file. An example is included below. Note the addition of the "ha" parameter with a value of "false", and the omission of the "replica" roles.
+6. Run the pe\_xl plan with the inputs created. Example:
+```
+        bolt plan run pe_xl \
+          --inventory nodes.yaml \
+          --modulepath ~/modules \
+          --params @params.json 
+```
+
+Example nodes.yaml Bolt inventory file:
+
+```yaml
+
+---
+groups:
+  - name: pe_xl_nodes
+    config:
+      transport: ssh
+      ssh:
+        host-key-check: false
+        user: centos
+        run-as: root
+        tty: true
+    nodes:
+      - pe-xl-core-0.lab1.puppet.vm
+      - pe-xl-core-1.lab1.puppet.vm
+      - pe-xl-compiler-0.lab1.puppet.vm
+      - pe-xl-compiler-1.lab1.puppet.vm
+```
+
+Example params.json Bolt parameters file:
+
+```json
+{
+  "install": true,
+  "configure": true,
+  "upgrade": false,
+  "ha": false,
+
+  "master_host": "pe-xl-core-0.lab1.puppet.vm",
+  "puppetdb_database_host": "pe-xl-core-1.lab1.puppet.vm",
+  "master_replica_host": "",
+  "puppetdb_database_replica_host": "",
+  "compiler_hosts": [
+    "pe-xl-compiler-0.lab1.puppet.vm",
+    "pe-xl-compiler-1.lab1.puppet.vm"
+  ],
+
+  "console_password": "puppetlabs",
+  "dns_alt_names": [ "puppet", "puppet.lab1.puppet.vm" ],
+  "compiler_pool_address": "puppet.lab1.puppet.vm",
+  "version": "2019.1.0"
+}
+```

--- a/documentation/install_and_configure_without_ha.md
+++ b/documentation/install_and_configure_without_ha.md
@@ -3,7 +3,7 @@
 * TODO: add this doc as a section to basic_usage.md instead?
 
 Please see the [basic_usage.md](basic_usage.md) document for reference; this document will avoid repeating the information covered there.
-The install, configure, and upgrade plans covered in the [basic_usage.md](basic_usage.md) document can also set up the Extra Large environment without HA by setting the optional `ha` parameter to `false` in the params.json file (see the [example](#example-params.json-bolt-parameters-file) below).
+The install, configure, and upgrade plans covered in the [basic_usage.md](basic_usage.md) document can also set up the Extra Large environment without HA by omitting the optional settings `master_replica_host` and `puppetdb_database_replica_host` in the params.json file (see the [example](#example-params.json-bolt-parameters-file) below).
 
 ## Basic usage instructions
 
@@ -11,7 +11,7 @@ The install, configure, and upgrade plans covered in the [basic_usage.md](basic_
 2. Install Bolt on a jumphost. This can be the master, or any other system.
 3. Download or git clone the pe\_xl module and put it somewhere on the jumphost, e.g. ~/modules/pe\_xl.
 4. Create an inventory file with connection information. An example is included below.
-5. Create a parameters file. An example is included below. Note the addition of the "ha" parameter with a value of "false", and the omission of the "replica" roles.
+5. Create a parameters file. An example is included below. Note the omission of the `master_replica_host` and `puppetdb_database_replica_host` parameters.
 6. Run the pe\_xl plan with the inputs created. Example:
 ```
         bolt plan run pe_xl \
@@ -48,12 +48,9 @@ groups:
   "install": true,
   "configure": true,
   "upgrade": false,
-  "ha": false,
 
   "master_host": "pe-xl-core-0.lab1.puppet.vm",
   "puppetdb_database_host": "pe-xl-core-1.lab1.puppet.vm",
-  "master_replica_host": "",
-  "puppetdb_database_replica_host": "",
   "compiler_hosts": [
     "pe-xl-compiler-0.lab1.puppet.vm",
     "pe-xl-compiler-1.lab1.puppet.vm"

--- a/documentation/install_and_configure_without_ha.md
+++ b/documentation/install_and_configure_without_ha.md
@@ -3,7 +3,7 @@
 * TODO: add this doc as a section to basic_usage.md instead?
 
 Please see the [basic_usage.md](basic_usage.md) document for reference; this document will avoid repeating the information covered there.
-The plans covered in this document can also set up the Extra Large environment without HA by setting the optional `ha` parameter to `false` in the params.json file.
+The install, configure, and upgrade plans covered in the [basic_usage.md](basic_usage.md) document can also set up the Extra Large environment without HA by setting the optional `ha` parameter to `false` in the params.json file (see the [example](#example-params.json-bolt-parameters-file) below).
 
 ## Basic usage instructions
 
@@ -20,7 +20,7 @@ The plans covered in this document can also set up the Extra Large environment w
           --params @params.json 
 ```
 
-Example nodes.yaml Bolt inventory file:
+### Example nodes.yaml Bolt inventory file
 
 ```yaml
 
@@ -41,7 +41,7 @@ groups:
       - pe-xl-compiler-1.lab1.puppet.vm
 ```
 
-Example params.json Bolt parameters file:
+### Example params.json Bolt parameters file
 
 ```json
 {

--- a/manifests/setup/node_manager.pp
+++ b/manifests/setup/node_manager.pp
@@ -50,14 +50,15 @@ class pe_xl::setup::node_manager (
   # Because the group does not have any data by default this does not impact
   # out-of-box configuration of the group.
   node_group { 'PE Master':
-    parent => 'PE Infrastructure',
-    rule   => ['or',
+    parent    => 'PE Infrastructure',
+    rule      => ['or',
       ['and', ['=', ['trusted', 'extensions', 'pp_role'], 'pe_xl::compiler']],
       ['=', 'name', $master_host],
     ],
-    data   => {
+    data      => {
       'pe_repo' => { 'compile_master_pool_address' => $compiler_pool_address },
     },
+    variables => { 'pe_master' => true },
   }
 
   # This class has to be included here because puppet_enterprise is declared

--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -22,8 +22,6 @@ plan pe_xl::configure (
   String[1]           $stagingdir = '/tmp',
 ) {
 
-  # TODO: remove 'SLV-365' comments
-
   # Allow for the configure task to be run local to the master.
   $master_target = $executing_on_master ? {
     true  => "local://${master_host}",

--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -45,16 +45,6 @@ plan pe_xl::configure (
 
   # Set up the console node groups to configure the various hosts in their
   # roles
-
-  # SLV-365
-  # run_task('pe_xl::configure_node_groups', $master_target,
-  #   master_host                    => $master_host,
-  #   master_replica_host            => $master_replica_host,
-  #   puppetdb_database_host         => $puppetdb_database_host,
-  #   puppetdb_database_replica_host => $puppetdb_database_replica_host,
-  #   compiler_pool_address          => $compiler_pool_address,
-  # )
-
   if $ha {
     run_task('pe_xl::configure_node_groups', $master_target,
       master_host                    => $master_host,
@@ -74,22 +64,6 @@ plan pe_xl::configure (
   # Run Puppet in no-op on the compilers so that their status in PuppetDB
   # is updated and they can be identified by the puppet_enterprise module as
   # CMs
-
-  # SLV-365
-  # run_task('pe_xl::puppet_runonce', [$compiler_hosts, $master_replica_host],
-  #   noop => true,
-  # )
-
-  # in this case assigning a variable seems less efficient...
-  # if $ha {
-  #   $runonce_hosts = [$compiler_hosts, $master_replica_host]
-  # }
-  # else {
-  #   $runonce_hosts = $compiler_hosts
-  # }
-  # 
-  # run_task('pe_xl::puppet_runonce', $runonce_hosts, noop => true)
-
   if $ha {
     run_task('pe_xl::puppet_runonce', [$compiler_hosts, $master_replica_host],
       noop => true,
@@ -100,13 +74,6 @@ plan pe_xl::configure (
 
   # Run Puppet on the PuppetDB Database hosts to update their auth
   # configuration to allow the compilers to connect
-
-  # SLV-365
-  # run_task('pe_xl::puppet_runonce', [
-  #   $puppetdb_database_host,
-  #   $puppetdb_database_replica_host,
-  # ])
-
   if $ha {
     run_task('pe_xl::puppet_runonce', [
       $puppetdb_database_host,
@@ -121,19 +88,6 @@ plan pe_xl::configure (
   # that a service restart of pe-puppetserver doesn't cause Puppet runs on
   # other nodes to fail.
   run_task('pe_xl::puppet_runonce', $master_target)
-
-  # SLV-365 
-  # Run the PE Replica Provision
-  # run_task('pe_xl::provision_replica', $master_target,
-  #   master_replica         => $master_replica_host,
-  #   token_file             => $token_file,
-  # )
-
-  # # Run the PE Replica Enable
-  # run_task('pe_xl::enable_replica', $master_target,
-  #   master_replica         => $master_replica_host,
-  #   token_file             => $token_file,
-  # )
 
   if $ha {
     # Run the PE Replica Provision
@@ -151,14 +105,6 @@ plan pe_xl::configure (
   }
 
   # Run Puppet everywhere to pick up last remaining config tweaks
-
-  # SLV-365
-  # run_task('pe_xl::puppet_runonce', [
-  #   $master_target, $master_replica_host,
-  #   $puppetdb_database_host, $puppetdb_database_replica_host,
-  #   $compiler_hosts,
-  # ].pe_xl::flatten_compact())
-
   if $ha {
     $all_hosts = [
       $master_target,

--- a/plans/configure.pp
+++ b/plans/configure.pp
@@ -1,7 +1,7 @@
 # @summary Configure first-time classification and HA setup
 #
 plan pe_xl::configure (
-  Boolean             $ha,
+  Boolean             $ha = true,
   String[1]           $master_host,
   String[1]           $puppetdb_database_host,
   String[1]           $master_replica_host,

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -8,7 +8,6 @@ plan pe_xl (
   Boolean $install   = false,
   Boolean $configure = false,
   Boolean $upgrade   = false,
-  Boolean $ha        = true,
 
   Optional[String[1]]        $master_host = undef,
   Optional[String[1]]        $puppetdb_database_host = undef,
@@ -30,7 +29,6 @@ plan pe_xl (
 
   if $install {
     run_plan('pe_xl::install',
-      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,
@@ -48,7 +46,6 @@ plan pe_xl (
 
   if $configure {
     run_plan('pe_xl::configure',
-      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,
@@ -65,7 +62,6 @@ plan pe_xl (
 
   if $upgrade {
     run_plan('pe_xl::upgrade',
-      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -8,6 +8,7 @@ plan pe_xl (
   Boolean $install   = false,
   Boolean $configure = false,
   Boolean $upgrade   = false,
+  Boolean $ha        = true,
 
   Optional[String[1]]        $master_host = undef,
   Optional[String[1]]        $puppetdb_database_host = undef,
@@ -29,6 +30,7 @@ plan pe_xl (
 
   if $install {
     run_plan('pe_xl::install',
+      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,
@@ -46,6 +48,7 @@ plan pe_xl (
 
   if $configure {
     run_plan('pe_xl::configure',
+      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,
@@ -62,6 +65,7 @@ plan pe_xl (
 
   if $upgrade {
     run_plan('pe_xl::upgrade',
+      ha                             => $ha,
       master_host                    => $master_host,
       puppetdb_database_host         => $puppetdb_database_host,
       master_replica_host            => $master_replica_host,

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -163,14 +163,14 @@ plan pe_xl::install (
   # Get the master installation up and running. The installer will
   # "fail" because PuppetDB can't start. That's expected.
   without_default_logging() || {
-    notice("Starting: task pe_xl::pe_install on ${master_host}")
+    out::message("Starting: task pe_xl::pe_install on ${master_host}")
     run_task('pe_xl::pe_install', $master_host,
       _catch_errors         => true,
       tarball               => $upload_tarball_path,
       peconf                => '/tmp/pe.conf',
       shortcircuit_puppetdb => true,
     )
-    notice("Finished: task pe_xl::pe_install on ${master_host}")
+    out::message("Finished: task pe_xl::pe_install on ${master_host}")
   }
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
@@ -251,9 +251,9 @@ plan pe_xl::install (
   # Do a Puppet agent run to ensure certificate requests have been submitted
   # These runs will "fail", and that's expected.
   without_default_logging() || {
-    notice("Starting: task pe_xl::puppet_runonce on ${agent_installer_hosts}")
+    out::message("Starting: task pe_xl::puppet_runonce on ${agent_installer_hosts}")
     run_task('pe_xl::puppet_runonce', $agent_installer_hosts, {_catch_errors => true})
-    notice("Finished: task pe_xl::puppet_runonce on ${agent_installer_hosts}")
+    out::message("Finished: task pe_xl::puppet_runonce on ${agent_installer_hosts}")
   }
 
   # Ensure some basic configuration on the master needed at install time.

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -1,6 +1,7 @@
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #
 plan pe_xl::install (
+  Boolean             $ha,
   String[1]           $master_host,
   String[1]           $puppetdb_database_host,
   String[1]           $master_replica_host,
@@ -15,26 +16,85 @@ plan pe_xl::install (
   String[1]           $stagingdir = '/tmp',
 ) {
 
+  # TODO: remove 'SLV-365' comments
+
   # Define a number of host groupings for use later in the plan
 
-  $all_hosts = [
+  # SLV-365 - separate core / ha hosts
+  # $all_hosts = [
+  #   $master_host,
+  #   $puppetdb_database_host,
+  #   $compiler_hosts,
+  #   $master_replica_host,
+  #   $puppetdb_database_replica_host,
+  # ].pe_xl::flatten_compact()
+
+  if $ha {
+    out::message('Proceeding with Extra Large HA installation...')
+  } else {
+    out::message('Proceeding with basic Extra Large installation...')
+  }
+
+  $core_hosts = [
     $master_host,
     $puppetdb_database_host,
     $compiler_hosts,
+  ]
+
+  $ha_hosts = [
     $master_replica_host,
     $puppetdb_database_replica_host,
-  ].pe_xl::flatten_compact()
+  ]
 
-  $pe_installer_hosts = [
-    $master_host,
-    $puppetdb_database_host,
-    $master_replica_host,
-  ].pe_xl::flatten_compact()
+  if $ha {
+    $all_hosts = [
+      $core_hosts,
+      $ha_hosts,
+    ].pe_xl::flatten_compact()
+  } else {
+    $all_hosts = [
+      $core_hosts,
+    ].pe_xl::flatten_compact()
+  }
 
-  $agent_installer_hosts = [
-    $compiler_hosts,
-    $master_replica_host,
-  ].pe_xl::flatten_compact()
+  out::message("all_hosts: ${all_hosts}")
+
+  # SLV-365
+  # $pe_installer_hosts = [
+  #   $master_host,
+  #   $puppetdb_database_host,
+  #   $master_replica_host,
+  # ].pe_xl::flatten_compact()
+
+  if $ha {
+    $pe_installer_hosts = [
+      $master_host,
+      $puppetdb_database_host,
+      $master_replica_host,
+    ].pe_xl::flatten_compact()
+  } else {
+    $pe_installer_hosts = [
+      $master_host,
+      $puppetdb_database_host,
+    ].pe_xl::flatten_compact()
+  }
+
+  # SLV-365 -
+  # $agent_installer_hosts = [
+  #   $compiler_hosts,
+  #   $master_replica_host,
+  # ].pe_xl::flatten_compact()
+
+  if $ha {
+    $agent_installer_hosts = [
+      $compiler_hosts,
+      $master_replica_host,
+    ].pe_xl::flatten_compact()
+  } else {
+    $agent_installer_hosts = [
+      $compiler_hosts,
+    ].pe_xl::flatten_compact()
+  }
 
   # There is currently a problem with OID names in csr_attributes.yaml for some
   # installs. Use the raw OIDs for now.
@@ -43,8 +103,15 @@ plan pe_xl::install (
   $pp_role        = '1.3.6.1.4.1.34380.1.1.13'
 
   # Clusters A and B are used to divide PuppetDB availability for compilers
-  $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
-  $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
+
+  # SLV-365
+  # $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
+  # $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
+
+  if $ha {
+    $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
+    $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
+  }
 
   $dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
 
@@ -70,23 +137,51 @@ plan pe_xl::install (
     puppetdb_database_host => $puppetdb_database_host,
   )
 
-  $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
-    master_host            => $master_host,
-    puppetdb_database_host => $puppetdb_database_replica_host,
-  )
+  # SLV-365
+  # $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
+  #   master_host            => $master_host,
+  #   puppetdb_database_host => $puppetdb_database_replica_host,
+  # )
+
+  if $ha {
+    $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
+      master_host            => $master_host,
+      puppetdb_database_host => $puppetdb_database_replica_host,
+    )
+  }
 
   # Upload the pe.conf files to the hosts that need them
   pe_xl::file_content_upload($master_pe_conf, '/tmp/pe.conf', $master_host)
   pe_xl::file_content_upload($puppetdb_database_pe_conf, '/tmp/pe.conf', $puppetdb_database_host)
-  pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
+
+  # SLV-365
+  # pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
+
+  if $ha {
+    pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
+  }
 
   # Download the PE tarball and send it to the nodes that need it
   $pe_tarball_name     = "puppet-enterprise-${version}-el-7-x86_64.tar.gz"
   $local_tarball_path  = "${stagingdir}/${pe_tarball_name}"
   $upload_tarball_path = "/tmp/${pe_tarball_name}"
 
+  # SLV-365
+  # run_plan('pe_xl::util::retrieve_and_upload',
+  #   nodes       => [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host],
+  #   source      => "https://s3.amazonaws.com/pe-builds/released/${version}/puppet-enterprise-${version}-el-7-x86_64.tar.gz",
+  #   local_path  => $local_tarball_path,
+  #   upload_path => $upload_tarball_path,
+  # )
+
+  if $ha {
+    $retrieve_and_upload_hosts = [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host]
+  } else {
+    $retrieve_and_upload_hosts = [$master_host, $puppetdb_database_host]
+  }
+
   run_plan('pe_xl::util::retrieve_and_upload',
-    nodes       => [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host],
+    nodes       => $retrieve_and_upload_hosts,
     source      => "https://s3.amazonaws.com/pe-builds/released/${version}/puppet-enterprise-${version}-el-7-x86_64.tar.gz",
     local_path  => $local_tarball_path,
     upload_path => $upload_tarball_path,
@@ -115,16 +210,30 @@ plan pe_xl::install (
       | HEREDOC
   )
 
-  run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
-    path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
-    content => @("HEREDOC"),
+  # SLV-365
+  # run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
+  #   path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
+  #   content => @("HEREDOC"),
+  #     ---
+  #     extension_requests:
+  #       ${pp_application}: "puppet"
+  #       ${pp_role}: "pe_xl::puppetdb_database"
+  #       ${pp_cluster}: "B"
+  #     | HEREDOC
+  # )
+
+  if $ha {
+    run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
+      path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
+      content => @("HEREDOC"),
       ---
       extension_requests:
         ${pp_application}: "puppet"
         ${pp_role}: "pe_xl::puppetdb_database"
         ${pp_cluster}: "B"
       | HEREDOC
-  )
+    )
+  }
 
   # Get the master installation up and running. The installer will
   # "fail" because PuppetDB can't start. That's expected.
@@ -140,19 +249,78 @@ plan pe_xl::install (
   }
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
-  run_task('pe_xl::mkdir_p_file', $master_host,
-    path    => '/etc/puppetlabs/puppet/autosign.conf',
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet',
-    mode    => '0644',
-    content => @("HEREDOC"),
-      ${puppetdb_database_host}
-      ${puppetdb_database_replica_host}
-      | HEREDOC
-  )
+
+  # SLV-365
+  # run_task('pe_xl::mkdir_p_file', $master_host,
+  #   path    => '/etc/puppetlabs/puppet/autosign.conf',
+  #   owner   => 'pe-puppet',
+  #   group   => 'pe-puppet',
+  #   mode    => '0644',
+  #   content => @("HEREDOC"),
+  #     ${puppetdb_database_host}
+  #     ${puppetdb_database_replica_host}
+  #     | HEREDOC
+  # )
+
+  # TODO: resolve syntax error in this approach
+  # if $ha {
+  #   $content = @("HEREDOC"),
+  #       ${puppetdb_database_host}
+  #       ${puppetdb_database_replica_host}
+  #       | HEREDOC
+  # } else {
+  #   $content = @("HEREDOC"),
+  #       ${puppetdb_database_host}
+  #       | HEREDOC
+  # }
+
+  # run_task('pe_xl::mkdir_p_file', $master_host,
+  #   path    => '/etc/puppetlabs/puppet/autosign.conf',
+  #   owner   => 'pe-puppet',
+  #   group   => 'pe-puppet',
+  #   mode    => '0644',
+  #   content => $content
+  # )
+
+  # TODO: replace with the commented approach above if resolved
+  if $ha {
+    run_task('pe_xl::mkdir_p_file', $master_host,
+      path    => '/etc/puppetlabs/puppet/autosign.conf',
+      owner   => 'pe-puppet',
+      group   => 'pe-puppet',
+      mode    => '0644',
+      content => @("HEREDOC"),
+        ${puppetdb_database_host}
+        ${puppetdb_database_replica_host}
+        | HEREDOC
+    )
+  } else {
+    run_task('pe_xl::mkdir_p_file', $master_host,
+      path    => '/etc/puppetlabs/puppet/autosign.conf',
+      owner   => 'pe-puppet',
+      group   => 'pe-puppet',
+      mode    => '0644',
+      content => @("HEREDOC"),
+        ${puppetdb_database_host}
+        | HEREDOC
+    )
+  }
 
   # Run the PE installer on the puppetdb database hosts
-  run_task('pe_xl::pe_install', [$puppetdb_database_host, $puppetdb_database_replica_host],
+
+  # SLV-365
+  # run_task('pe_xl::pe_install', [$puppetdb_database_host, $puppetdb_database_replica_host],
+  #   tarball => $upload_tarball_path,
+  #   peconf  => '/tmp/pe.conf',
+  # )
+
+  if $ha {
+    $database_hosts = [$puppetdb_database_host, $puppetdb_database_replica_host]
+  } else {
+    $database_hosts = [$puppetdb_database_host]
+  }
+
+  run_task('pe_xl::pe_install', $database_hosts,
     tarball => $upload_tarball_path,
     peconf  => '/tmp/pe.conf',
   )
@@ -184,38 +352,87 @@ plan pe_xl::install (
   )
 
   # Deploy the PE agent to all remaining hosts
-  run_task('pe_xl::agent_install', $master_replica_host,
-    server        => $master_host,
-    install_flags => [
+  ##############
+  # SLV-365 - clusters A & B?
+  ##############
+  # run_task('pe_xl::agent_install', $master_replica_host,
+  #   server        => $master_host,
+  #   install_flags => [
+  #     '--puppet-service-ensure', 'stopped',
+  #     "main:dns_alt_names=${dns_alt_names_csv}",
+  #     'extension_requests:pp_application=puppet',
+  #     'extension_requests:pp_role=pe_xl::master',
+  #     'extension_requests:pp_cluster=B',
+  #   ],
+  # )
+  #
+  # run_task('pe_xl::agent_install', $cm_cluster_a,
+  #   server        => $master_host,
+  #   install_flags => [
+  #     '--puppet-service-ensure', 'stopped',
+  #     "main:dns_alt_names=${dns_alt_names_csv}",
+  #     'extension_requests:pp_application=puppet',
+  #     'extension_requests:pp_role=pe_xl::compiler',
+  #     'extension_requests:pp_cluster=A',
+  #   ],
+  # )
+  #
+  # run_task('pe_xl::agent_install', $cm_cluster_b,
+  #   server        => $master_host,
+  #   install_flags => [
+  #     '--puppet-service-ensure', 'stopped',
+  #     "main:dns_alt_names=${dns_alt_names_csv}",
+  #     'extension_requests:pp_application=puppet',
+  #     'extension_requests:pp_role=pe_xl::compiler',
+  #     'extension_requests:pp_cluster=B',
+  #   ],
+  # )
+
+  if $ha {
+    run_task('pe_xl::agent_install', $master_replica_host,
+      server        => $master_host,
+      install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
       'extension_requests:pp_application=puppet',
       'extension_requests:pp_role=pe_xl::master',
       'extension_requests:pp_cluster=B',
-    ],
-  )
+      ],
+    )
 
-  run_task('pe_xl::agent_install', $cm_cluster_a,
-    server        => $master_host,
-    install_flags => [
+    run_task('pe_xl::agent_install', $cm_cluster_a,
+      server        => $master_host,
+      install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
       'extension_requests:pp_application=puppet',
       'extension_requests:pp_role=pe_xl::compiler',
       'extension_requests:pp_cluster=A',
-    ],
-  )
+      ],
+    )
 
-  run_task('pe_xl::agent_install', $cm_cluster_b,
-    server        => $master_host,
-    install_flags => [
+    run_task('pe_xl::agent_install', $cm_cluster_b,
+      server        => $master_host,
+      install_flags => [
       '--puppet-service-ensure', 'stopped',
       "main:dns_alt_names=${dns_alt_names_csv}",
       'extension_requests:pp_application=puppet',
       'extension_requests:pp_role=pe_xl::compiler',
       'extension_requests:pp_cluster=B',
-    ],
-  )
+      ],
+    )
+  } else {
+    run_task('pe_xl::agent_install', $compiler_hosts,
+      server        => $master_host,
+      install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::compiler',
+      'extension_requests:pp_cluster=A',
+      ],
+    )
+  }
 
   # Do a Puppet agent run to ensure certificate requests have been submitted
   # These runs will "fail", and that's expected.

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -56,7 +56,7 @@ plan pe_xl::install (
   $pe_installer_hosts = [
     $master_host,
     $puppetdb_database_host,
-    $master_replica_host,
+    $puppetdb_database_replica_host,
   ].pe_xl::flatten_compact()
 
   $agent_installer_hosts = [

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -1,12 +1,12 @@
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #
 plan pe_xl::install (
-  Boolean             $ha = true,
   String[1]           $master_host,
   String[1]           $puppetdb_database_host,
-  String[1]           $master_replica_host,
-  String[1]           $puppetdb_database_replica_host,
   Array[String[1]]    $compiler_hosts = [ ],
+
+  Optional[String[1]] $master_replica_host = undef,
+  Optional[String[1]] $puppetdb_database_replica_host = undef,
 
   String[1]           $console_password,
   String[1]           $version = '2018.1.3',
@@ -20,48 +20,49 @@ plan pe_xl::install (
   $core_hosts = [
     $master_host,
     $puppetdb_database_host,
-    $compiler_hosts,
-  ]
+  ].pe_xl::flatten_compact()
 
   $ha_hosts = [
     $master_replica_host,
     $puppetdb_database_replica_host,
-  ]
+  ].pe_xl::flatten_compact()
 
-  if $ha {
-    $all_hosts = [
-      $core_hosts,
-      $ha_hosts,
-    ].pe_xl::flatten_compact()
-  } else {
-    $all_hosts = [
-      $core_hosts,
-    ].pe_xl::flatten_compact()
+  $ha_replica_target = [
+    $master_replica_host,
+  ].pe_xl::flatten_compact()
+
+  $ha_database_target = [
+    $puppetdb_database_replica_host,
+  ].pe_xl::flatten_compact()
+
+  # Ensure valid input for HA
+  $ha = $ha_hosts.size ? {
+    0       => false,
+    2       => true,
+    default => fail("Must specify either both or neither of master_replica_host, puppetdb_database_replica_host"),
   }
 
-  if $ha {
-    $pe_installer_hosts = [
-      $master_host,
-      $puppetdb_database_host,
-      $master_replica_host,
-    ].pe_xl::flatten_compact()
-  } else {
-    $pe_installer_hosts = [
-      $master_host,
-      $puppetdb_database_host,
-    ].pe_xl::flatten_compact()
-  }
+  $all_hosts = [
+    $core_hosts,
+    $ha_hosts,
+    $compiler_hosts,
+  ].pe_xl::flatten_compact()
 
-  if $ha {
-    $agent_installer_hosts = [
-      $compiler_hosts,
-      $master_replica_host,
-    ].pe_xl::flatten_compact()
-  } else {
-    $agent_installer_hosts = [
-      $compiler_hosts,
-    ].pe_xl::flatten_compact()
-  }
+  $database_hosts = [
+    $puppetdb_database_host,
+    $puppetdb_database_replica_host,
+  ].pe_xl::flatten_compact()
+
+  $pe_installer_hosts = [
+    $master_host,
+    $puppetdb_database_host,
+    $master_replica_host,
+  ].pe_xl::flatten_compact()
+
+  $agent_installer_hosts = [
+    $compiler_hosts,
+    $master_replica_host,
+  ].pe_xl::flatten_compact()
 
   # There is currently a problem with OID names in csr_attributes.yaml for some
   # installs. Use the raw OIDs for now.
@@ -73,6 +74,10 @@ plan pe_xl::install (
   if $ha {
     $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
     $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
+  }
+  else {
+    $cm_cluster_a = $compiler_hosts
+    $cm_cluster_b = []
   }
 
   $dns_alt_names_csv = $dns_alt_names.reduce |$csv,$x| { "${csv},${x}" }
@@ -99,34 +104,23 @@ plan pe_xl::install (
     puppetdb_database_host => $puppetdb_database_host,
   )
 
-  if $ha {
-    $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
-      master_host            => $master_host,
-      puppetdb_database_host => $puppetdb_database_replica_host,
-    )
-  }
+  $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
+    master_host            => $master_host,
+    puppetdb_database_host => $puppetdb_database_replica_host,
+  )
 
   # Upload the pe.conf files to the hosts that need them
   pe_xl::file_content_upload($master_pe_conf, '/tmp/pe.conf', $master_host)
   pe_xl::file_content_upload($puppetdb_database_pe_conf, '/tmp/pe.conf', $puppetdb_database_host)
-
-  if $ha {
-    pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
-  }
+  pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $ha_database_target)
 
   # Download the PE tarball and send it to the nodes that need it
   $pe_tarball_name     = "puppet-enterprise-${version}-el-7-x86_64.tar.gz"
   $local_tarball_path  = "${stagingdir}/${pe_tarball_name}"
   $upload_tarball_path = "/tmp/${pe_tarball_name}"
 
-  if $ha {
-    $retrieve_and_upload_hosts = [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host]
-  } else {
-    $retrieve_and_upload_hosts = [$master_host, $puppetdb_database_host]
-  }
-
   run_plan('pe_xl::util::retrieve_and_upload',
-    nodes       => $retrieve_and_upload_hosts,
+    nodes       => $pe_installer_hosts,
     source      => "https://s3.amazonaws.com/pe-builds/released/${version}/puppet-enterprise-${version}-el-7-x86_64.tar.gz",
     local_path  => $local_tarball_path,
     upload_path => $upload_tarball_path,
@@ -155,18 +149,16 @@ plan pe_xl::install (
       | HEREDOC
   )
 
-  if $ha {
-    run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
-      path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
-      content => @("HEREDOC"),
-        ---
-        extension_requests:
-          ${pp_application}: "puppet"
-          ${pp_role}: "pe_xl::puppetdb_database"
-          ${pp_cluster}: "B"
-        | HEREDOC
-    )
-  }
+  run_task('pe_xl::mkdir_p_file', $ha_database_target,
+    path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
+    content => @("HEREDOC"),
+      ---
+      extension_requests:
+        ${pp_application}: "puppet"
+        ${pp_role}: "pe_xl::puppetdb_database"
+        ${pp_cluster}: "B"
+      | HEREDOC
+  )
 
   # Get the master installation up and running. The installer will
   # "fail" because PuppetDB can't start. That's expected.
@@ -182,36 +174,15 @@ plan pe_xl::install (
   }
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
-  if $ha {
-    run_task('pe_xl::mkdir_p_file', $master_host,
-      path    => '/etc/puppetlabs/puppet/autosign.conf',
-      owner   => 'pe-puppet',
-      group   => 'pe-puppet',
-      mode    => '0644',
-      content => @("HEREDOC"),
-        ${puppetdb_database_host}
-        ${puppetdb_database_replica_host}
-        | HEREDOC
-    )
-  } else {
-    run_task('pe_xl::mkdir_p_file', $master_host,
-      path    => '/etc/puppetlabs/puppet/autosign.conf',
-      owner   => 'pe-puppet',
-      group   => 'pe-puppet',
-      mode    => '0644',
-      content => @("HEREDOC"),
-        ${puppetdb_database_host}
-        | HEREDOC
-    )
-  }
+  run_task('pe_xl::mkdir_p_file', $master_host,
+    path    => '/etc/puppetlabs/puppet/autosign.conf',
+    owner   => 'pe-puppet',
+    group   => 'pe-puppet',
+    mode    => '0644',
+    content => $database_hosts.reduce |$memo,$host| { "${host}\n${memo}" },
+  )
 
   # Run the PE installer on the puppetdb database hosts
-  if $ha {
-    $database_hosts = [$puppetdb_database_host, $puppetdb_database_replica_host]
-  } else {
-    $database_hosts = [$puppetdb_database_host]
-  }
-
   run_task('pe_xl::pe_install', $database_hosts,
     tarball => $upload_tarball_path,
     peconf  => '/tmp/pe.conf',
@@ -244,51 +215,38 @@ plan pe_xl::install (
   )
 
   # Deploy the PE agent to all remaining hosts
-  if $ha {
-    run_task('pe_xl::agent_install', $master_replica_host,
-      server        => $master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::master',
-        'extension_requests:pp_cluster=B',
-      ],
-    )
+  run_task('pe_xl::agent_install', $ha_replica_target,
+    server        => $master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::master',
+      'extension_requests:pp_cluster=B',
+    ],
+  )
 
-    run_task('pe_xl::agent_install', $cm_cluster_a,
-      server        => $master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::compiler',
-        'extension_requests:pp_cluster=A',
-      ],
-    )
+  run_task('pe_xl::agent_install', $cm_cluster_a,
+    server        => $master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::compiler',
+      'extension_requests:pp_cluster=A',
+    ],
+  )
 
-    run_task('pe_xl::agent_install', $cm_cluster_b,
-      server        => $master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::compiler',
-        'extension_requests:pp_cluster=B',
-      ],
-    )
-  } else {
-    run_task('pe_xl::agent_install', $compiler_hosts,
-      server        => $master_host,
-      install_flags => [
-        '--puppet-service-ensure', 'stopped',
-        "main:dns_alt_names=${dns_alt_names_csv}",
-        'extension_requests:pp_application=puppet',
-        'extension_requests:pp_role=pe_xl::compiler',
-        'extension_requests:pp_cluster=A',
-      ],
-    )
-  }
+  run_task('pe_xl::agent_install', $cm_cluster_b,
+    server        => $master_host,
+    install_flags => [
+      '--puppet-service-ensure', 'stopped',
+      "main:dns_alt_names=${dns_alt_names_csv}",
+      'extension_requests:pp_application=puppet',
+      'extension_requests:pp_role=pe_xl::compiler',
+      'extension_requests:pp_cluster=B',
+    ],
+  )
 
   # Do a Puppet agent run to ensure certificate requests have been submitted
   # These runs will "fail", and that's expected.

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -159,12 +159,12 @@ plan pe_xl::install (
     run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
       path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
       content => @("HEREDOC"),
-      ---
-      extension_requests:
-        ${pp_application}: "puppet"
-        ${pp_role}: "pe_xl::puppetdb_database"
-        ${pp_cluster}: "B"
-      | HEREDOC
+        ---
+        extension_requests:
+          ${pp_application}: "puppet"
+          ${pp_role}: "pe_xl::puppetdb_database"
+          ${pp_cluster}: "B"
+        | HEREDOC
     )
   }
 
@@ -248,44 +248,44 @@ plan pe_xl::install (
     run_task('pe_xl::agent_install', $master_replica_host,
       server        => $master_host,
       install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::master',
-      'extension_requests:pp_cluster=B',
+        '--puppet-service-ensure', 'stopped',
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        'extension_requests:pp_application=puppet',
+        'extension_requests:pp_role=pe_xl::master',
+        'extension_requests:pp_cluster=B',
       ],
     )
 
     run_task('pe_xl::agent_install', $cm_cluster_a,
       server        => $master_host,
       install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::compiler',
-      'extension_requests:pp_cluster=A',
+        '--puppet-service-ensure', 'stopped',
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        'extension_requests:pp_application=puppet',
+        'extension_requests:pp_role=pe_xl::compiler',
+        'extension_requests:pp_cluster=A',
       ],
     )
 
     run_task('pe_xl::agent_install', $cm_cluster_b,
       server        => $master_host,
       install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::compiler',
-      'extension_requests:pp_cluster=B',
+        '--puppet-service-ensure', 'stopped',
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        'extension_requests:pp_application=puppet',
+        'extension_requests:pp_role=pe_xl::compiler',
+        'extension_requests:pp_cluster=B',
       ],
     )
   } else {
     run_task('pe_xl::agent_install', $compiler_hosts,
       server        => $master_host,
       install_flags => [
-      '--puppet-service-ensure', 'stopped',
-      "main:dns_alt_names=${dns_alt_names_csv}",
-      'extension_requests:pp_application=puppet',
-      'extension_requests:pp_role=pe_xl::compiler',
-      'extension_requests:pp_cluster=A',
+        '--puppet-service-ensure', 'stopped',
+        "main:dns_alt_names=${dns_alt_names_csv}",
+        'extension_requests:pp_application=puppet',
+        'extension_requests:pp_role=pe_xl::compiler',
+        'extension_requests:pp_cluster=A',
       ],
     )
   }

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -1,7 +1,7 @@
 # @summary Perform initial installation of Puppet Enterprise Extra Large
 #
 plan pe_xl::install (
-  Boolean             $ha,
+  Boolean             $ha = true,
   String[1]           $master_host,
   String[1]           $puppetdb_database_host,
   String[1]           $master_replica_host,

--- a/plans/install.pp
+++ b/plans/install.pp
@@ -16,25 +16,7 @@ plan pe_xl::install (
   String[1]           $stagingdir = '/tmp',
 ) {
 
-  # TODO: remove 'SLV-365' comments
-
   # Define a number of host groupings for use later in the plan
-
-  # SLV-365 - separate core / ha hosts
-  # $all_hosts = [
-  #   $master_host,
-  #   $puppetdb_database_host,
-  #   $compiler_hosts,
-  #   $master_replica_host,
-  #   $puppetdb_database_replica_host,
-  # ].pe_xl::flatten_compact()
-
-  if $ha {
-    out::message('Proceeding with Extra Large HA installation...')
-  } else {
-    out::message('Proceeding with basic Extra Large installation...')
-  }
-
   $core_hosts = [
     $master_host,
     $puppetdb_database_host,
@@ -57,15 +39,6 @@ plan pe_xl::install (
     ].pe_xl::flatten_compact()
   }
 
-  out::message("all_hosts: ${all_hosts}")
-
-  # SLV-365
-  # $pe_installer_hosts = [
-  #   $master_host,
-  #   $puppetdb_database_host,
-  #   $master_replica_host,
-  # ].pe_xl::flatten_compact()
-
   if $ha {
     $pe_installer_hosts = [
       $master_host,
@@ -78,12 +51,6 @@ plan pe_xl::install (
       $puppetdb_database_host,
     ].pe_xl::flatten_compact()
   }
-
-  # SLV-365 -
-  # $agent_installer_hosts = [
-  #   $compiler_hosts,
-  #   $master_replica_host,
-  # ].pe_xl::flatten_compact()
 
   if $ha {
     $agent_installer_hosts = [
@@ -103,11 +70,6 @@ plan pe_xl::install (
   $pp_role        = '1.3.6.1.4.1.34380.1.1.13'
 
   # Clusters A and B are used to divide PuppetDB availability for compilers
-
-  # SLV-365
-  # $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
-  # $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
-
   if $ha {
     $cm_cluster_a = $compiler_hosts.filter |$index,$cm| { $index % 2 == 0 }
     $cm_cluster_b = $compiler_hosts.filter |$index,$cm| { $index % 2 != 0 }
@@ -137,12 +99,6 @@ plan pe_xl::install (
     puppetdb_database_host => $puppetdb_database_host,
   )
 
-  # SLV-365
-  # $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
-  #   master_host            => $master_host,
-  #   puppetdb_database_host => $puppetdb_database_replica_host,
-  # )
-
   if $ha {
     $puppetdb_database_replica_pe_conf = epp('pe_xl/puppetdb_database-pe.conf.epp',
       master_host            => $master_host,
@@ -154,9 +110,6 @@ plan pe_xl::install (
   pe_xl::file_content_upload($master_pe_conf, '/tmp/pe.conf', $master_host)
   pe_xl::file_content_upload($puppetdb_database_pe_conf, '/tmp/pe.conf', $puppetdb_database_host)
 
-  # SLV-365
-  # pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
-
   if $ha {
     pe_xl::file_content_upload($puppetdb_database_replica_pe_conf, '/tmp/pe.conf', $puppetdb_database_replica_host)
   }
@@ -165,14 +118,6 @@ plan pe_xl::install (
   $pe_tarball_name     = "puppet-enterprise-${version}-el-7-x86_64.tar.gz"
   $local_tarball_path  = "${stagingdir}/${pe_tarball_name}"
   $upload_tarball_path = "/tmp/${pe_tarball_name}"
-
-  # SLV-365
-  # run_plan('pe_xl::util::retrieve_and_upload',
-  #   nodes       => [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host],
-  #   source      => "https://s3.amazonaws.com/pe-builds/released/${version}/puppet-enterprise-${version}-el-7-x86_64.tar.gz",
-  #   local_path  => $local_tarball_path,
-  #   upload_path => $upload_tarball_path,
-  # )
 
   if $ha {
     $retrieve_and_upload_hosts = [$master_host, $puppetdb_database_host, $puppetdb_database_replica_host]
@@ -210,18 +155,6 @@ plan pe_xl::install (
       | HEREDOC
   )
 
-  # SLV-365
-  # run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
-  #   path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
-  #   content => @("HEREDOC"),
-  #     ---
-  #     extension_requests:
-  #       ${pp_application}: "puppet"
-  #       ${pp_role}: "pe_xl::puppetdb_database"
-  #       ${pp_cluster}: "B"
-  #     | HEREDOC
-  # )
-
   if $ha {
     run_task('pe_xl::mkdir_p_file', $puppetdb_database_replica_host,
       path    => '/etc/puppetlabs/puppet/csr_attributes.yaml',
@@ -249,40 +182,6 @@ plan pe_xl::install (
   }
 
   # Configure autosigning for the puppetdb database hosts 'cause they need it
-
-  # SLV-365
-  # run_task('pe_xl::mkdir_p_file', $master_host,
-  #   path    => '/etc/puppetlabs/puppet/autosign.conf',
-  #   owner   => 'pe-puppet',
-  #   group   => 'pe-puppet',
-  #   mode    => '0644',
-  #   content => @("HEREDOC"),
-  #     ${puppetdb_database_host}
-  #     ${puppetdb_database_replica_host}
-  #     | HEREDOC
-  # )
-
-  # TODO: resolve syntax error in this approach
-  # if $ha {
-  #   $content = @("HEREDOC"),
-  #       ${puppetdb_database_host}
-  #       ${puppetdb_database_replica_host}
-  #       | HEREDOC
-  # } else {
-  #   $content = @("HEREDOC"),
-  #       ${puppetdb_database_host}
-  #       | HEREDOC
-  # }
-
-  # run_task('pe_xl::mkdir_p_file', $master_host,
-  #   path    => '/etc/puppetlabs/puppet/autosign.conf',
-  #   owner   => 'pe-puppet',
-  #   group   => 'pe-puppet',
-  #   mode    => '0644',
-  #   content => $content
-  # )
-
-  # TODO: replace with the commented approach above if resolved
   if $ha {
     run_task('pe_xl::mkdir_p_file', $master_host,
       path    => '/etc/puppetlabs/puppet/autosign.conf',
@@ -307,13 +206,6 @@ plan pe_xl::install (
   }
 
   # Run the PE installer on the puppetdb database hosts
-
-  # SLV-365
-  # run_task('pe_xl::pe_install', [$puppetdb_database_host, $puppetdb_database_replica_host],
-  #   tarball => $upload_tarball_path,
-  #   peconf  => '/tmp/pe.conf',
-  # )
-
   if $ha {
     $database_hosts = [$puppetdb_database_host, $puppetdb_database_replica_host]
   } else {
@@ -352,42 +244,6 @@ plan pe_xl::install (
   )
 
   # Deploy the PE agent to all remaining hosts
-  ##############
-  # SLV-365 - clusters A & B?
-  ##############
-  # run_task('pe_xl::agent_install', $master_replica_host,
-  #   server        => $master_host,
-  #   install_flags => [
-  #     '--puppet-service-ensure', 'stopped',
-  #     "main:dns_alt_names=${dns_alt_names_csv}",
-  #     'extension_requests:pp_application=puppet',
-  #     'extension_requests:pp_role=pe_xl::master',
-  #     'extension_requests:pp_cluster=B',
-  #   ],
-  # )
-  #
-  # run_task('pe_xl::agent_install', $cm_cluster_a,
-  #   server        => $master_host,
-  #   install_flags => [
-  #     '--puppet-service-ensure', 'stopped',
-  #     "main:dns_alt_names=${dns_alt_names_csv}",
-  #     'extension_requests:pp_application=puppet',
-  #     'extension_requests:pp_role=pe_xl::compiler',
-  #     'extension_requests:pp_cluster=A',
-  #   ],
-  # )
-  #
-  # run_task('pe_xl::agent_install', $cm_cluster_b,
-  #   server        => $master_host,
-  #   install_flags => [
-  #     '--puppet-service-ensure', 'stopped',
-  #     "main:dns_alt_names=${dns_alt_names_csv}",
-  #     'extension_requests:pp_application=puppet',
-  #     'extension_requests:pp_role=pe_xl::compiler',
-  #     'extension_requests:pp_cluster=B',
-  #   ],
-  # )
-
   if $ha {
     run_task('pe_xl::agent_install', $master_replica_host,
       server        => $master_host,

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,6 +1,7 @@
 # @summary Upgrade an Extra Large stack from one .z to the next
 #
 plan pe_xl::upgrade (
+  Boolean   $ha,
   String[1] $master_host,
   String[1] $puppetdb_database_host,
   String[1] $master_replica_host,
@@ -11,6 +12,8 @@ plan pe_xl::upgrade (
   String[1] $stagingdir = '/tmp',
   String[1] $pe_source  = "https://s3.amazonaws.com/pe-builds/released/${version}/puppet-enterprise-${version}-el-7-x86_64.tar.gz",
 ) {
+
+  # TODO: remove 'SLV-365' comments
 
   # Look up which hosts are compilers in the stack
   # We look up groups of CMs separately since when they are upgraded is determined
@@ -23,22 +26,51 @@ plan pe_xl::upgrade (
       !(certname = "${master_host}") }
     | PQL
 
-  $compiler_cluster_master_replica_hosts = puppetdb_query(@("PQL")).map |$node| { $node['certname'] }
-    resources[certname] { 
-      type = "Class" and
-      title = "Puppet_enterprise::Profile::Puppetdb" and
-      parameters.database_host = "${puppetdb_database_replica_host}" and
-      !(certname = "${master_replica_host}") }
-    | PQL
+  # SLV-365
+  # $compiler_cluster_master_replica_hosts = puppetdb_query(@("PQL")).map |$node| { $node['certname'] }
+  #   resources[certname] { 
+  #     type = "Class" and
+  #     title = "Puppet_enterprise::Profile::Puppetdb" and
+  #     parameters.database_host = "${puppetdb_database_replica_host}" and
+  #     !(certname = "${master_replica_host}") }
+  #   | PQL
 
-  $all_hosts = [
-    $master_host,
-    $puppetdb_database_host,
-    $master_replica_host,
-    $puppetdb_database_replica_host,
-    $compiler_cluster_master_hosts,
-    $compiler_cluster_master_replica_hosts,
-  ].pe_xl::flatten_compact()
+  if $ha {
+    $compiler_cluster_master_replica_hosts = puppetdb_query(@("PQL")).map |$node| { $node['certname'] }
+      resources[certname] { 
+        type = "Class" and
+        title = "Puppet_enterprise::Profile::Puppetdb" and
+        parameters.database_host = "${puppetdb_database_replica_host}" and
+        !(certname = "${master_replica_host}") }
+      | PQL
+  }
+
+  # SLV-365
+  # $all_hosts = [
+  #   $master_host,
+  #   $puppetdb_database_host,
+  #   $master_replica_host,
+  #   $puppetdb_database_replica_host,
+  #   $compiler_cluster_master_hosts,
+  #   $compiler_cluster_master_replica_hosts,
+  # ].pe_xl::flatten_compact()
+
+  if $ha {
+    $all_hosts = [
+      $master_host,
+      $puppetdb_database_host,
+      $master_replica_host,
+      $puppetdb_database_replica_host,
+      $compiler_cluster_master_hosts,
+      $compiler_cluster_master_replica_hosts,
+    ].pe_xl::flatten_compact()
+  } else {
+    $all_hosts = [
+      $master_host,
+      $puppetdb_database_host,
+      $compiler_cluster_master_hosts,
+    ].pe_xl::flatten_compact()
+  }
 
   $master_local = "local://${master_host}"
 
@@ -47,11 +79,30 @@ plan pe_xl::upgrade (
   # Download the PE tarball on the nodes that need it
   $upload_tarball_path = "/tmp/puppet-enterprise-${version}-el-7-x86_64.tar.gz"
 
-  run_task('pe_xl::download', [
+  # SLV-365
+  # run_task('pe_xl::download', [
+  #     $master_host,
+  #     $puppetdb_database_host,
+  #     $puppetdb_database_replica_host
+  #   ],
+  #   source => $pe_source,
+  #   path   => $upload_tarball_path,
+  # )
+
+  if $ha {
+    $download_hosts = [
       $master_host,
       $puppetdb_database_host,
-      $puppetdb_database_replica_host
-    ],
+      $puppetdb_database_replica_host,
+    ].pe_xl::flatten_compact()
+  } else {
+    $download_hosts = [
+      $master_host,
+      $puppetdb_database_host,
+    ].pe_xl::flatten_compact()
+  }
+
+  run_task('pe_xl::download', $download_hosts,
     source => $pe_source,
     path   => $upload_tarball_path,
   )
@@ -117,27 +168,52 @@ plan pe_xl::upgrade (
     server => $master_host,
   )
 
+  # SLV-365
   # Shut down PuppetDB on CMs that use the PMR's PDB PG
-  run_task('service', $compiler_cluster_master_replica_hosts,
-    action => 'stop',
-    name   => 'pe-puppetdb',
-  )
+  # run_task('service', $compiler_cluster_master_replica_hosts,
+  #   action => 'stop',
+  #   name   => 'pe-puppetdb',
+  # )
 
-  # Run the upgrade.sh script on the master replica host
-  run_task('pe_xl::agent_upgrade', $master_replica_host,
-    server => $master_host,
-  )
+  # # Run the upgrade.sh script on the master replica host
+  # run_task('pe_xl::agent_upgrade', $master_replica_host,
+  #   server => $master_host,
+  # )
 
-  # Upgrade the master replica's PuppetDB PostgreSQL host
-  run_task('pe_xl::pe_install', $puppetdb_database_replica_host,
-    tarball => $upload_tarball_path,
-  )
-  run_task('pe_xl::puppet_runonce', $puppetdb_database_replica_host)
+  # # Upgrade the master replica's PuppetDB PostgreSQL host
+  # run_task('pe_xl::pe_install', $puppetdb_database_replica_host,
+  #   tarball => $upload_tarball_path,
+  # )
+  # run_task('pe_xl::puppet_runonce', $puppetdb_database_replica_host)
 
-  # Upgrade the compiler group B hosts
-  run_task('pe_xl::agent_upgrade', $compiler_cluster_master_replica_hosts,
-    server => $master_host,
-  )
+  # # Upgrade the compiler group B hosts
+  # run_task('pe_xl::agent_upgrade', $compiler_cluster_master_replica_hosts,
+  #   server => $master_host,
+  # )
+
+  if $ha {
+    # Shut down PuppetDB on CMs that use the PMR's PDB PG
+    run_task('service', $compiler_cluster_master_replica_hosts,
+      action => 'stop',
+      name   => 'pe-puppetdb',
+    )
+
+    # Run the upgrade.sh script on the master replica host
+    run_task('pe_xl::agent_upgrade', $master_replica_host,
+      server => $master_host,
+    )
+
+    # Upgrade the master replica's PuppetDB PostgreSQL host
+    run_task('pe_xl::pe_install', $puppetdb_database_replica_host,
+      tarball => $upload_tarball_path,
+    )
+    run_task('pe_xl::puppet_runonce', $puppetdb_database_replica_host)
+
+    # Upgrade the compiler group B hosts
+    run_task('pe_xl::agent_upgrade', $compiler_cluster_master_replica_hosts,
+      server => $master_host,
+    )
+  }
 
   # Ensure Puppet running on all infrastructure hosts
   run_task('service', $all_hosts,

--- a/plans/upgrade.pp
+++ b/plans/upgrade.pp
@@ -1,7 +1,7 @@
 # @summary Upgrade an Extra Large stack from one .z to the next
 #
 plan pe_xl::upgrade (
-  Boolean   $ha,
+  Boolean   $ha = true,
   String[1] $master_host,
   String[1] $puppetdb_database_host,
   String[1] $master_replica_host,

--- a/tasks/configure_node_groups.sh
+++ b/tasks/configure_node_groups.sh
@@ -167,4 +167,6 @@ class configure_node_groups (
   }
 
 }
+
+include configure_node_groups
 EOF

--- a/tasks/configure_node_groups.sh
+++ b/tasks/configure_node_groups.sh
@@ -167,3 +167,4 @@ class configure_node_groups (
   }
 
 }
+EOF

--- a/tasks/configure_node_groups.sh
+++ b/tasks/configure_node_groups.sh
@@ -49,14 +49,15 @@ class configure_node_groups (
   # Because the group does not have any data by default this does not impact
   # out-of-box configuration of the group.
   node_group { 'PE Master':
-    parent => 'PE Infrastructure',
-    rule   => ['or',
+    parent    => 'PE Infrastructure',
+    rule      => ['or',
       ['and', ['=', ['trusted', 'extensions', 'pp_role'], 'pe_xl::compiler']],
       ['=', 'name', $master_host],
     ],
-    data   => {
+    data      => {
       'pe_repo' => { 'compile_master_pool_address' => $compiler_pool_address },
     },
+    variables => { 'pe_master' => true },
   }
 
   # This class has to be included here because puppet_enterprise is declared

--- a/tasks/configure_node_groups.sh
+++ b/tasks/configure_node_groups.sh
@@ -3,7 +3,12 @@
 
 /opt/puppetlabs/bin/puppet apply --environment production <<'EOF'
 
-function param($name) { inline_template("<%= ENV['PT_${name}'] %>") }
+function param($name) {
+  ($var = inline_template("<%= ENV['PT_${name}'] %>")) ? {
+    ''      => undef,
+    default => $var,
+  }
+}
 
 class configure_node_groups (
   String[1] $master_host            = param('master_host'),

--- a/templates/puppetdb_database-pe.conf.epp
+++ b/templates/puppetdb_database-pe.conf.epp
@@ -1,5 +1,5 @@
 <%- | String[1] $master_host,
-      String[1] $puppetdb_database_host,
+      Optional[String[1]] $puppetdb_database_host,
 | -%>
 #----------------------------------------------------------------------------
 # Puppet Enterprise installer configuration file


### PR DESCRIPTION
This update adds an optional ha parameter (default = true) and conditionally performs the HA steps in the install, configure, and upgrade plans. There should be no impact to the existing functionality.

Please see [SLV-365](https://tickets.puppetlabs.com/browse/SLV-365) for context regarding the SLV team's need for this feature in provisioning environments for testing with [gatling-puppet-load-test](https://github.com/puppetlabs/gatling-puppet-load-test).

Additonally, the [`provision_pe_xl_nodes.rb`](https://github.com/billclaytor/gatling-puppet-load-test/blob/SLV-504/docs/abs_utils.md#provision_pe_xl_nodesrb) script has been added to GPLT as part of SLV-365 (see [SLV-483](https://tickets.puppetlabs.com/browse/SLV-483)) to assist in the provisioning of AWS EC2 hosts and creation of the `nodes.yaml` and `params.json` files for use with pe_xl.
